### PR TITLE
replaced h4 with class h4

### DIFF
--- a/tpl/message/errors_modal.tpl
+++ b/tpl/message/errors_modal.tpl
@@ -6,7 +6,7 @@
                     <span aria-hidden="true">×</span>
                     <span class="visually-hidden-focusable">Close</span>
                 </button>
-                <h4 class="modal-title" id="basketModalLabel">Error</h4>
+                <div class="h4 modal-title" id="basketModalLabel">Error</div>
             </div>
             <div class="modal-body">
                 <div id="modalbasketFlyout" class="basketFlyout">

--- a/tpl/widget/minibasket/minibasket.tpl
+++ b/tpl/widget/minibasket/minibasket.tpl
@@ -13,7 +13,7 @@
                     <div class="modal-content">
                         [{block name="widget_minibasket_modal_header"}]
                         <div class="modal-header">
-                            <h4 class="modal-title" id="basketModalLabel">[{$oxcmp_basket->getItemsCount()}] [{oxmultilang ident="ITEMS_IN_BASKET"}]</h4>
+                            <div class="h4 modal-title" id="basketModalLabel">[{$oxcmp_basket->getItemsCount()}] [{oxmultilang ident="ITEMS_IN_BASKET"}]</div>
                             <button type="button" class="btn-close" data-bs-dismiss="modal">
                                 <span aria-hidden="true"></span>
                                 <span class="visually-hidden-focusable">[{oxmultilang ident="CLOSE"}]</span>


### PR DESCRIPTION
For SEO reasons better use h4 as class for not content headings.